### PR TITLE
Make the global Tom Select initializer robust and reusable

### DIFF
--- a/apps/website/pages/fact_create/fact_create.html
+++ b/apps/website/pages/fact_create/fact_create.html
@@ -66,22 +66,21 @@
 </div>
 
 <script>
-	// The fields are Tom Select-initialized globally (see base.html: window.initTomSelects), opting into
-	// "pick or create" via data-create / data-create-on-blur on the widgets. The only page-specific work is
-	// (re)initializing rows added at runtime by the "add another fact" button.
-	window.addEventListener('load', function () {
-		const addButton = document.getElementById('add-fact');
-		const container = document.getElementById('fact-forms');
-		const template = document.getElementById('empty-fact-row');
-		const totalForms = document.getElementById('id_form-TOTAL_FORMS');
+	window.addEventListener('load', () => {
+		const addButton = document.getElementById('add-fact')
+		const container = document.getElementById('fact-forms')
+		const template = document.getElementById('empty-fact-row')
+		// Django's management formset hidden input to handle how many forms we are sending
+		const totalForms = document.getElementById('id_{{ formset.prefix }}-TOTAL_FORMS');
 
-		addButton.addEventListener('click', function () {
-			const index = parseInt(totalForms.value, 10);
-			const wrapper = document.createElement('div');
-			wrapper.innerHTML = template.innerHTML.replace(/__prefix__/g, index);
-			container.appendChild(wrapper);
-			totalForms.value = index + 1;
-			window.initTomSelects(wrapper);
+		addButton.addEventListener('click', () => {
+			const index = parseInt(totalForms.value, 10)
+			const wrapper = document.createElement('div')
+            // Also part of Django's formset way to spawn new forms
+			wrapper.innerHTML = template.innerHTML.replace(/__prefix__/g, index)
+			container.appendChild(wrapper)
+			totalForms.value = index + 1
+			window.initTomSelects(wrapper)
 		});
 	});
 </script>

--- a/apps/website/pages/fact_create/fact_create.html
+++ b/apps/website/pages/fact_create/fact_create.html
@@ -66,26 +66,10 @@
 </div>
 
 <script>
-	// Tom Select for HKM fields. We deliberately use the `hkm-select` class (not the shared `tom-select`
-	// one) so the global initializer in base.html leaves these alone — it only handles the first match and
-	// never sees rows added dynamically. `create: true` is what turns "pick from a list" into "pick or type
-	// a new one".
-	function initHkmSelects(root) {
-		root.querySelectorAll('select.hkm-select').forEach(function (el) {
-			if (el.tomselect) return;
-			new TomSelect(el, {
-				create: true,
-				createOnBlur: true,
-				persist: false,
-				placeholder: el.dataset.placeholder || '',
-				maxOptions: null
-			});
-		});
-	}
-
+	// The fields are Tom Select-initialized globally (see base.html: window.initTomSelects), opting into
+	// "pick or create" via data-create / data-create-on-blur on the widgets. The only page-specific work is
+	// (re)initializing rows added at runtime by the "add another fact" button.
 	window.addEventListener('load', function () {
-		initHkmSelects(document);
-
 		const addButton = document.getElementById('add-fact');
 		const container = document.getElementById('fact-forms');
 		const template = document.getElementById('empty-fact-row');
@@ -97,7 +81,7 @@
 			wrapper.innerHTML = template.innerHTML.replace(/__prefix__/g, index);
 			container.appendChild(wrapper);
 			totalForms.value = index + 1;
-			initHkmSelects(wrapper);
+			window.initTomSelects(wrapper);
 		});
 	});
 </script>

--- a/apps/website/pages/fact_create/fact_create.py
+++ b/apps/website/pages/fact_create/fact_create.py
@@ -11,14 +11,36 @@ class FactForm(forms.Form):
 	# while Tom Select still lets you type a brand-new one. A ChoiceField would reject anything outside its
 	# `choices`; a CharField accepts whatever string is submitted, which is exactly the "pick or create"
 	# behaviour we want.
+	# `tom-select` + data-create* opt into the global "pick or create" initializer (see base.html).
 	subject = forms.CharField(
-		widget=forms.Select(attrs={'class': 'hkm-select', 'data-placeholder': 'subject (entity)'})
+		widget=forms.Select(
+			attrs={
+				'class': 'tom-select',
+				'data-create': 'true',
+				'data-create-on-blur': 'true',
+				'data-placeholder': 'subject (entity)',
+			}
+		)
 	)
 	predicate = forms.CharField(
-		widget=forms.Select(attrs={'class': 'hkm-select', 'data-placeholder': 'predicate'})
+		widget=forms.Select(
+			attrs={
+				'class': 'tom-select',
+				'data-create': 'true',
+				'data-create-on-blur': 'true',
+				'data-placeholder': 'predicate',
+			}
+		)
 	)
 	object = forms.CharField(
-		widget=forms.Select(attrs={'class': 'hkm-select', 'data-placeholder': 'object (entity or value)'})
+		widget=forms.Select(
+			attrs={
+				'class': 'tom-select',
+				'data-create': 'true',
+				'data-create-on-blur': 'true',
+				'data-placeholder': 'object (entity or value)',
+			}
+		)
 	)
 
 	def __init__(self, *args, entities=(), predicates=(), **kwargs):

--- a/apps/website/templates/base.html
+++ b/apps/website/templates/base.html
@@ -35,13 +35,28 @@
             </main>
         </div>
         <script>
+            // Initialize Tom Select on EVERY .tom-select element. Per-element behaviour is opted into with
+            // data attributes, so any page gets "pick or create" declaratively without its own script:
+            //   data-create="true"          -> allow creating a new option by typing
+            //   data-create-on-blur="true"  -> commit the typed value when the field loses focus
+            //   data-placeholder="..."      -> placeholder text
+            // Exposed as window.initTomSelects(root) so pages can initialize content they add at runtime
+            // (e.g. formset rows).
+            window.initTomSelects = function (root) {
+                (root || document).querySelectorAll('.tom-select').forEach(function (el) {
+                    if (el.tomselect) return;
+                    new TomSelect(el, {
+                        create: el.dataset.create === 'true',
+                        createOnBlur: el.dataset.createOnBlur === 'true',
+                        persist: false,
+                        placeholder: el.dataset.placeholder || undefined,
+                        maxOptions: null
+                    });
+                });
+            };
 
-            // Initialize Tom Select on all available selects
             window.addEventListener('load', function () {
-                const inputs = document.querySelectorAll('.tom-select');
-                if (inputs.length > 0) {
-                    new TomSelect('.tom-select', {});
-                }
+                window.initTomSelects(document);
             });
         </script>
     </body>

--- a/apps/website/templates/base.html
+++ b/apps/website/templates/base.html
@@ -40,24 +40,28 @@
             //   data-create="true"          -> allow creating a new option by typing
             //   data-create-on-blur="true"  -> commit the typed value when the field loses focus
             //   data-placeholder="..."      -> placeholder text
-            // Exposed as window.initTomSelects(root) so pages can initialize content they add at runtime
-            // (e.g. formset rows).
-            window.initTomSelects = function (root) {
-                (root || document).querySelectorAll('.tom-select').forEach(function (el) {
-                    if (el.tomselect) return;
+            function initTomSelects (root) {
+                (root || document).querySelectorAll('.tom-select').forEach(el => {
+                    if (el.tomselect) return
                     new TomSelect(el, {
                         create: el.dataset.create === 'true',
                         createOnBlur: el.dataset.createOnBlur === 'true',
                         persist: false,
                         placeholder: el.dataset.placeholder || undefined,
                         maxOptions: null
-                    });
-                });
-            };
+                    })
+                })
+            }
 
             window.addEventListener('load', function () {
-                window.initTomSelects(document);
-            });
+                initTomSelects(document)
+            })
+
+            document.addEventListener('htmx:load', function (evt) {
+                initTomSelects(evt.detail.elt)
+            })
+
+            window.initTomSelects = initTomSelects
         </script>
     </body>
 </html>


### PR DESCRIPTION
Stacked on `hkm-partial-prefix` (#49) — third of three PRs addressing review comments.

Addresses @dumaron's comment on the page-local Tom Select script in `fact_create.html`:
> This is actually useful for all pages. Can we fix the global snippet instead?

**`base.html`** — the global initializer was buggy: `new TomSelect('.tom-select', {})` only ever initialized the *first* matching element and never re-ran for content added at runtime. It now:
- initializes **every** `.tom-select` element;
- supports declarative per-element opt-ins via data attributes — `data-create`, `data-create-on-blur`, `data-placeholder` — so any page gets "pick or create" without its own script;
- is exposed as `window.initTomSelects(root)` so pages can initialize rows they add dynamically.

**`fact_create`** migrates onto it: the widgets use `class="tom-select"` + `data-create`/`data-create-on-blur`, and the page script is reduced to the formset "add another fact" handler (which now calls `window.initTomSelects`). The bespoke `initHkmSelects` is gone.

Side benefit: `pair_transactions`, `project_detail`, and `event_create` (which already use `.tom-select`) are now correctly initialized too — previously only the first select on each page worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)